### PR TITLE
Add global notification service that notifies when a new version is available.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,6 +20,9 @@ import { MainToolbarComponent } from './core-ui/main-toolbar/main-toolbar.compon
 import { AppLocationService } from './core/app-location/app-location.service';
 import { GlobalUIService } from './core/app-sidenav-service/global-ui.service';
 import { DeviceTypeService } from './core/device-type/device-type.service';
+import {
+  GlobalNotificationService
+} from './core/global-notification-service/global-notification.service';
 import { GlobalSettingEnabledPipe } from './core/settings/setting-enabled/global-setting-enabled.pipe';
 import { SettingsService } from './core/settings/settings.service';
 import { AppRoute, GlobalSettings, Versioned } from './models';
@@ -47,6 +50,9 @@ export class AppComponent implements OnInit {
   private readonly globalUIService: GlobalUIService = inject(GlobalUIService);
   private readonly settingsService: SettingsService = inject(SettingsService);
   private readonly settingsStore = inject(SettingsStore);
+
+  // Even though the service is unused here, it is injected to ensure the service is registered and initialized.
+  private readonly globalNotificationService: GlobalNotificationService = inject(GlobalNotificationService);
 
   public settings: Signal<Versioned<GlobalSettings>> = computed(() => {
     return this.settingsService.settings();

--- a/src/app/core/global-notification-service/global-notification-service.service.spec.ts
+++ b/src/app/core/global-notification-service/global-notification-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GlobalNotificationService } from './global-notification.service';
+
+describe('GlobalNotificationServiceService', () => {
+  let service: GlobalNotificationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GlobalNotificationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/global-notification-service/global-notification.service.ts
+++ b/src/app/core/global-notification-service/global-notification.service.ts
@@ -1,0 +1,95 @@
+import { effect, EffectRef, inject, Injectable, OnDestroy, signal, WritableSignal } from '@angular/core';
+import {
+  MatSnackBar,
+  MatSnackBarConfig,
+  MatSnackBarDismiss,
+  MatSnackBarRef,
+  TextOnlySnackBar,
+} from '@angular/material/snack-bar';
+import { SwUpdate, VersionEvent } from '@angular/service-worker';
+import { Subscription } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GlobalNotificationService implements OnDestroy {
+
+  private readonly swUpdate: SwUpdate = inject(SwUpdate);
+  private readonly snackbar: MatSnackBar = inject(MatSnackBar);
+
+  private readonly subscriptions: Subscription = new Subscription();
+  private readonly versionDetectedMessageShown: WritableSignal<boolean> = signal(false);
+  private readonly versionDetectedTimeoutComplete: WritableSignal<boolean> = signal(false);
+  private readonly newVersionReady: WritableSignal<boolean> = signal(false);
+  private readonly newVersionReadyMessageEffectRef?: EffectRef;
+
+  private readonly newVersionDetectedMessageSnackbarConfig: Readonly<MatSnackBarConfig> = {
+    horizontalPosition: 'end',
+    verticalPosition: 'bottom',
+    politeness: 'off',
+    duration: 8_000,
+  };
+
+  private readonly versionReadyMessageSnackbarConfig: Readonly<MatSnackBarConfig> = {
+    horizontalPosition: 'end',
+    verticalPosition: 'bottom',
+    politeness: 'polite',
+    duration: 12_000,
+  };
+
+  constructor() {
+    this.subscriptions.add(this.swUpdate.versionUpdates.subscribe((versionEvent: VersionEvent) => {
+      let snackbarRef: MatSnackBarRef<TextOnlySnackBar> | undefined = undefined;
+      switch (versionEvent.type) {
+        case 'VERSION_DETECTED':
+          snackbarRef = this.snackbar.open('New version detected. Downloading update...', 'OK', this.newVersionDetectedMessageSnackbarConfig);
+
+          snackbarRef.afterDismissed().subscribe((value: MatSnackBarDismiss) => {
+            if (value.dismissedByAction) {
+              // When the user dismisses the notification, wait before showing the data loaded message.
+              setTimeout(() => {
+                this.versionDetectedTimeoutComplete.set(true);
+              }, 1500);
+            } else {
+              this.versionDetectedTimeoutComplete.set(true);
+            }
+          });
+
+          this.versionDetectedMessageShown.set(true);
+          break;
+        case 'VERSION_INSTALLATION_FAILED':
+          console.warn('VERSION_INSTALLATION_FAILED');
+          break;
+        case 'VERSION_READY':
+          this.newVersionReady.set(true);
+          break;
+        case 'NO_NEW_VERSION_DETECTED':
+          this.newVersionReadyMessageEffectRef?.destroy();
+          break;
+      }
+    }));
+
+    this.newVersionReadyMessageEffectRef = effect(() => {
+      const versionDetectedMessageShown = this.versionDetectedMessageShown();
+      const versionDetectedTimeoutComplete = this.versionDetectedTimeoutComplete();
+      const newVersionReady = this.newVersionReady();
+
+      if (versionDetectedMessageShown && versionDetectedTimeoutComplete && newVersionReady) {
+        const snackbarRef = this.snackbar.open('New version ready. Refresh the page to use the latest version.', 'Refresh', this.versionReadyMessageSnackbarConfig);
+        snackbarRef.afterDismissed().subscribe((value: MatSnackBarDismiss) => {
+          // Only reload when the user clicked the refresh button.
+          if (value.dismissedByAction) {
+            window.location.reload();
+          }
+        });
+
+        // Destroy the effect since we don't need to listen for changes to the version anymore.
+        this.newVersionReadyMessageEffectRef?.destroy();
+      }
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+}


### PR DESCRIPTION
Add global notification service that notifies when a new version is available.

This currently is generally only going to trigger once when the app is loaded, as no manual checks for new versions are performed. Resolves #45.