### PR TITLE
Add support for haptic feedback when clicking on the observation behvior buttons.

### DIFF
--- a/src/app/frequency/frequency-record/observation-session/observation-session-form/observation-session-form.component.html
+++ b/src/app/frequency/frequency-record/observation-session/observation-session-form/observation-session-form.component.html
@@ -17,6 +17,27 @@
       <span class="show-hide-comparison-toggle">
 
         @if (isPrimaryStudent()) {
+          <!-- Toggle haptic feedback button -->
+          @if (hapticFeedbackAvailable()) {
+            <button mat-icon-button
+                    (click)="toggleHapticFeedback()"
+                    [matTooltip]="settingsStore.frequencyDataSettings.enableHapticFeedback() ? 'Disable haptic feedback' : 'Enable haptic feedback (this may not work on all devices)'"
+                    matTooltipPosition="above"
+                    type="button"
+            >
+              <mat-icon>
+                @if (settingsStore.frequencyDataSettings.enableHapticFeedback()) {
+                  vibration
+                } @else {
+                  <!-- As of 2025-04-14, the material icons do not include an icon for disabling vibration. This is a custom version of the vibration icon adapted from existing material icons. -->
+                  <svg width="100%" height="100%" viewBox="0 0 24 24">
+                    <path d="M16.245,20.986c-0.08,0.009 -0.162,0.014 -0.245,0.014l-8,0c-0.55,0 -1.021,-0.196 -1.413,-0.587c-0.391,-0.392 -0.587,-0.863 -0.587,-1.413l-0,-13.186l-2.498,-3.701l1.534,-1.036l14.663,21.667l-1.542,1.074l-1.912,-2.832Zm-8.245,-12.21l0,10.224l6.904,0l-6.904,-10.224Zm0.573,-5.776l7.427,0c0.55,0 1.021,0.196 1.412,0.588c0.392,0.391 0.588,0.862 0.588,1.412l0,11.93l-2,-2.956l-0,-8.974l-6.073,0l-1.354,-2Zm-8.573,12l0,-6l2,0l0,6l-2,0Zm3,2l0,-10l2,0l0,10l-2,0Zm19,-2l0,-6l2,0l-0,6l-2,0Zm-3,2l0,-10l2,0l0,10l-2,0Z"/>
+                  </svg>
+                }
+              </mat-icon>
+            </button>
+          }
+
           <!-- Edit Student Button -->
           <a mat-icon-button
              [routerLink]="editStudentRoute()"

--- a/src/app/frequency/frequency-record/observation-session/observation-session-form/observation-session-form.component.ts
+++ b/src/app/frequency/frequency-record/observation-session/observation-session-form/observation-session-form.component.ts
@@ -8,6 +8,7 @@ import {
   input,
   InputSignal,
   OnDestroy,
+  Signal,
   signal,
   WritableSignal,
 } from '@angular/core';
@@ -95,6 +96,15 @@ export class ObservationSessionFormComponent implements OnDestroy {
 
   public readonly isComparisonStudent: InputSignal<boolean> = input.required<boolean>();
   public readonly isPrimaryStudent: InputSignal<boolean> = input.required<boolean>();
+
+  public readonly hapticFeedbackAvailable: Signal<boolean> = signal(!!navigator.vibrate);
+
+  private readonly useHapticFeedback: Signal<boolean> = computed(() => {
+    const hapticFeedbackAvailable = this.hapticFeedbackAvailable();
+    const enableHapticFeedback = this.settingsStore.frequencyDataSettings.enableHapticFeedback();
+
+    return hapticFeedbackAvailable && enableHapticFeedback;
+  });
 
   /* Form Controls */
   public readonly notesFormControl: FormControl<string>;
@@ -226,6 +236,10 @@ export class ObservationSessionFormComponent implements OnDestroy {
   }
 
   public async addObservationEntry(behaviorId: BehaviorId): Promise<void> {
+    if (this.useHapticFeedback()) {
+      navigator.vibrate([30]);
+    }
+
     const success = await this.currentObservationSessionStore.addBehaviorEntry({
       observationSessionId: this.currentObservationSessionStore.currentObservation.id(),
       behaviorId: behaviorId,
@@ -249,6 +263,10 @@ export class ObservationSessionFormComponent implements OnDestroy {
 
   public async showHideComparisonStudent(showHide: boolean): Promise<void> {
     await this.currentObservationSessionStore.showHideComparisonStudent(showHide);
+  }
+
+  public toggleHapticFeedback(): void {
+    this.settingsStore.toggleFrequencyDataHapticFeedback();
   }
 
   private countQueryBuilder(behaviorId: BehaviorId) {

--- a/src/app/settings/settings.model.ts
+++ b/src/app/settings/settings.model.ts
@@ -7,6 +7,7 @@ export interface NewGlobalSettings {
   schedulerSettings: SchedulerSettings;
   feedbackSettings: FeedbackSettings;
   displaySettings: DisplaySettings;
+  frequencyDataSettings: FrequencyDataSettings;
 }
 
 export interface Setting_New<T> {
@@ -63,3 +64,7 @@ export interface DateTimeDisplaySettings {
 export type OptionalDateTimeDisplaySettings = DateTimeDisplaySettings & {
   enabled: boolean;
 };
+
+export interface FrequencyDataSettings {
+  enableHapticFeedback: boolean;
+}

--- a/src/app/settings/settings.store.ts
+++ b/src/app/settings/settings.store.ts
@@ -68,6 +68,9 @@ export const globalUserSettingsDefaults: Readonly<NewGlobalSettings> = {
       format: {},
     },
   },
+  frequencyDataSettings: {
+    enableHapticFeedback: false,
+  },
 };
 
 // export type NewGlobalSettings_Defaults = NewGlobalSettings;
@@ -160,6 +163,14 @@ export const SettingsStore = signalStore(
             ...state.displaySettings.dateTimeFormat,
             ...dateTimeFormatOptions,
           },
+        },
+      }));
+    },
+    toggleFrequencyDataHapticFeedback(): void {
+      patchState(store, (state) => ({
+        frequencyDataSettings: {
+          ...state.frequencyDataSettings,
+          enableHapticFeedback: !state.frequencyDataSettings.enableHapticFeedback,
         },
       }));
     },


### PR DESCRIPTION
Add support for haptic feedback when clicking on the observation behvior buttons.

This will not be available on all devices due to browser support. See: https://caniuse.com/?search=navigator.vibrate.

Disabled by default.

Resolves #70.